### PR TITLE
Fix Docker for Apple architecture

### DIFF
--- a/packages/server/docker-compose.yml
+++ b/packages/server/docker-compose.yml
@@ -3,6 +3,7 @@
       mysql:
         container_name: $MYSQL_DATABASE
         image: mysql
+        platform: linux/x86_64
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         volumes:


### PR DESCRIPTION
# Description

Docker on apple architecture requires running a specific version of the Mysql image.

# How to test?

Has currently been tested on Mac M1X and Mac Intel architecture. To test 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
