### PR TITLE
Fix database variables

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,5 +1,5 @@
 # Your API will run on this port
-API_PORT="5000"
+API_PORT="5005"
 
 # The path the API will run from
 API_PATH="/api"

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,11 +1,3 @@
-# Database credentials
-DB_HOST="127.0.0.1"
-DB_PORT="33306"
-DB_USER="root"
-DB_PASSWORD="root"
-DB_DATABASE="final_project_db"
-
-
 # Your API will run on this port
 API_PORT="5000"
 
@@ -28,10 +20,12 @@ NODE_ENV=development
 FIREBASE_APP_API_KEY=[fill key]
 
 # Database
-MYSQL_ROOT_PASSWORD=password
-MYSQL_DATABASE=final_project_database
-MYSQL_USER=final_project_db_user
-MYSQL_PASSWORD=final_project_db_user_password
+DB_HOST="127.0.0.1"
+MYSQL_PORT="3306"
+MYSQL_ROOT_PASSWORD="password"
+MYSQL_DATABASE="final_project_database"
+MYSQL_USER="final_project_db_user"
+MYSQL_PASSWORD="final_project_db_user_password"
 
 # Debug Express
 #DEBUG=express:*

--- a/packages/server/knexfile.js
+++ b/packages/server/knexfile.js
@@ -6,10 +6,10 @@ module.exports = {
     client: 'mysql2',
     connection: {
       host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_DATABASE,
+      port: process.env.MYSQL_PORT,
+      user: process.env.MYSQL_USER,
+      password: process.env.MYSQL_PASSWORD,
+      database: process.env.MYSQL_DATABASE,
     },
     pool: { min: 0, max: 7 },
     seeds: {
@@ -20,10 +20,10 @@ module.exports = {
     client: 'mysql2',
     connection: {
       host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_DATABASE,
+      port: process.env.MYSQL_PORT,
+      user: process.env.MYSQL_USER,
+      password: process.env.MYSQL_PASSWORD,
+      database: process.env.MYSQL_DATABASE,
     },
     pool: { min: 0, max: 7 },
     seeds: {


### PR DESCRIPTION
# Description

There was some confusing duplication in env example and environment variables was not properly being loaded for Docker.

Now when starting the project with Docker the database port, user and password should automatically be used.

# How to test?

- Create `.env` file:
  - `cd packages/server`
  - `cp .env.example .env`
  - Optionally tweak values in `.env`
- Run docker
  - `docker compose up`
- Connect to database:
  - `mysql -h "127.0.0.1" -P 3306 -u final_project_db_user -p` (provided you did not change default vars)
  - Type password (`final_project_db_user_password` by default)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
